### PR TITLE
chore(readme): Fixed mistaken error description

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,6 @@ Shown when the `clamdscan` executable returns with the exit code other than 0 or
 
 ### antivirus_client_error ("could not be processed for virus scan")
 
-This means that the given file contains a virus detected by ClamAV.
-
 In this case the `clamdscan` executable did not finish its work successfully and
 an error was produced. This can be generally caused by the `clamav-daemon`
 service because of few different reasons:


### PR DESCRIPTION
Removing mistaken comment from "could not be processed" error description.
It mistakenly states that this indicates a virus has been found. When it means it could not scan the file.